### PR TITLE
Define a very simple logging implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["/.*"]
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "0.38.0", default-features = false, features = ["stdio", "pipe"] }
 errno = { version = "0.3.0", default-features = false, optional = true }
+log = { version = "0.4", default-features = false, optional = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48.0"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ write(2, "\n", 1
 atomic-dbg is `no_std`, however like `std`, it uses the stderr file descriptor
 ambiently, assuming that it's open.
 
+## Logging
+
+With the "log" feature enabled, atomic-dbg defines an `atomic_dbg::log::init`
+which installed a minimal logging implementation using the `eprintln` macro.
+
 [counterparts]: https://doc.rust-lang.org/stable/std/macro.dbg.html
 [in]: https://doc.rust-lang.org/stable/std/macro.eprintln.html
 [std]: https://doc.rust-lang.org/stable/std/macro.eprint.html

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -1,0 +1,14 @@
+#[cfg(feature = "log")]
+fn main() {
+    atomic_dbg::log::init();
+    log::trace!("This is an TRACE log message!");
+    log::debug!("This is an DEBUG log message!");
+    log::info!("This is an INFO log message!");
+    log::warn!("This is an WARN log message!");
+    log::error!("This is an ERROR log message!");
+}
+
+#[cfg(not(feature = "log"))]
+fn main() -> Result<(), &'static str> {
+    Err("This example requires --features=log.")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
 
+#[cfg(feature = "log")]
+pub mod log;
+
 use core::cmp::min;
 use core::fmt::{self, Write};
 #[cfg(windows)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,26 @@
+//! An extremely minimal log implementation that prints everything to `stderr`
+//! and has no configuration.
+
+struct Log;
+
+impl log::Log for Log {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        crate::eprintln!(
+            "{}: {} - {}",
+            record.metadata().target(),
+            record.level(),
+            record.args()
+        );
+    }
+
+    fn flush(&self) {}
+}
+
+pub fn init() {
+    log::set_max_level(log::LevelFilter::Trace);
+    log::set_logger(&Log).unwrap();
+}


### PR DESCRIPTION
Define a very simple logging implementation that works in terms of `eprintln`.